### PR TITLE
Implement async-runner-ch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/checkmate "0.4.0"
+(defproject cc.qbits/checkmate "0.4.1"
   :description "Retry stuff until it passes or break"
   :url "https://github.com/mpenet/checkmate"
   :license {:name "Eclipse Public License"

--- a/src/clj/qbits/checkmate.clj
+++ b/src/clj/qbits/checkmate.clj
@@ -46,7 +46,7 @@
                    default-callbacks
                    opts)]
         (loop [delays delays]
-          (let [[status ret :as step] (attempt this f)]
+          (let [[status ret] (attempt this f)]
             (case status
               ::success (when success (success ret))
               ::error (let [[delay & delays] delays]
@@ -86,7 +86,7 @@
                    default-callbacks
                    opts)]
         (async/go-loop [delays delays]
-          (let [[status ret :as step] (attempt this f)]
+          (let [[status ret] (attempt this f)]
             (case status
               ::success (when success (success ret))
               ::error (let [[delay & delays] delays]


### PR DESCRIPTION
Implement a runner that runs all inside an async/go

That's probably what delay-runner-ch should have been actually. Should we keep it?